### PR TITLE
Pin version of azure-devops-extension-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,12 +2255,12 @@
       }
     },
     "azure-devops-extension-api": {
-      "version": "1.154.1",
-      "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-1.154.1.tgz",
-      "integrity": "sha512-rv9cUoFxK8ceNS7AeWGEdZOASVHQmF1yGD7md97UJ7VGffcUqHp3cTnmIIddrAf0EpcOe3DsY03v9e6eI7sHag==",
+      "version": "1.153.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-1.153.2.tgz",
+      "integrity": "sha512-mnHVbbfsGOOVJ9wGchvPW8MHGb3hsGIw0WISbTvSwGz04qLA2QC+vbw/8LhW7Jn0PjmTkdysv46wOpnO+PshkA==",
       "dev": true,
       "requires": {
-        "azure-devops-extension-sdk": "~2.0.11",
+        "azure-devops-extension-sdk": "~2.0.10",
         "whatwg-fetch": "~3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/react-dom": "^16.8.5",
     "@types/react-redux": "^7.1.1",
     "@types/react-router-dom": "^4.3.4",
-    "azure-devops-extension-api": "^1.154.1",
+    "azure-devops-extension-api": "1.153.2",
     "azure-devops-extension-sdk": "^2.0.11",
     "azure-devops-ui": "^1.155.0",
     "core-js": "^3.1.4",


### PR DESCRIPTION
The "api-version" number was set to 5.1, but client Api Services also maintains a version of the required Api. In effect this meant that Azure DevOps Server 2019.1 would not work with the extension.
See https://github.com/gustavobergamim/azdevops-pipeline-approval/issues/3 for additional details.