### PR TITLE
 Loading and storing the last selection of repositories as a default filter

### DIFF
--- a/src/components/FilterBarHub.tsx
+++ b/src/components/FilterBarHub.tsx
@@ -50,7 +50,7 @@ export interface IFilterHubProps {
     item: IListBoxItem<TeamProjectReference | ProjectInfo>
   ) => void;
   selectedProject: DropdownSelection;
-  selectedRepos: DropdownSelection;
+  selectedRepos: DropdownMultiSelection;
   repositories: GitRepository[];
   selectedSourceBranches: DropdownMultiSelection;
   sourceBranchList: Data.BranchDropDownItem[];


### PR DESCRIPTION
Most users have a default selection of repositories they want to select, but have to make this selection every time this extension opens. This pull request remembers the last selection a user made and sets this as a default filter when the page opens again. The data is stored in the local storage. Optionally this could be done through a "Save" button (if requested).