### PR TITLE
Bugfix/203 sorting resets on refresh

### DIFF
--- a/src/tabs/PulRequestsTabData.tsx
+++ b/src/tabs/PulRequestsTabData.tsx
@@ -228,8 +228,19 @@ export function sortPullRequests(
   b: PullRequestModel
 ) {
   return UserPreferencesInstance.selectedDefaultSorting === "asc"
-    ? b.gitPullRequest.creationDate.getTime() -
-        a.gitPullRequest.creationDate.getTime()
-    : a.gitPullRequest.creationDate.getTime() -
-        b.gitPullRequest.creationDate.getTime();
+    ? comparePullRequestAge(a, b)
+    : -comparePullRequestAge(a, b); // Invert if descending
+}
+
+/**
+ * Compares the age of two pull requests.
+ * @returns A negative number if {@link a} is more recent than {@link b},
+ * a positive number if {@link a} is older than {@link b}, otherwise 0.
+ */
+export function comparePullRequestAge(
+  a: PullRequestModel,
+  b: PullRequestModel
+) {
+  return b.gitPullRequest.creationDate.getTime() -
+  a.gitPullRequest.creationDate.getTime();
 }

--- a/src/tabs/PulRequestsTabData.tsx
+++ b/src/tabs/PulRequestsTabData.tsx
@@ -13,7 +13,6 @@ import {
   WebApiTagDefinition
 } from "azure-devops-extension-api/Core/Core";
 import { PullRequestModel } from "../models/PullRequestModel";
-import { UserPreferencesInstance } from "../common";
 
 export const refsPreffix = "refs/heads/";
 

--- a/src/tabs/PulRequestsTabData.tsx
+++ b/src/tabs/PulRequestsTabData.tsx
@@ -6,6 +6,7 @@ import {
 } from "azure-devops-extension-api/Git/Git";
 import { IStatusProps } from "azure-devops-ui/Status";
 import { IColor } from "azure-devops-ui/Utilities/Color";
+import { SortOrder } from "azure-devops-ui/Table";
 import { IdentityRef } from "azure-devops-extension-api/WebApi/WebApi";
 import {
   TeamProjectReference,
@@ -193,6 +194,8 @@ export interface IPullRequestsTabState {
   errorMessage: string;
   pullRequestCount: number;
   savedProjects: string[];
+  /** Direction to sort pull request age in */
+  sortOrder: SortOrder;
 }
 
 export function sortBranchOrIdentity(
@@ -225,9 +228,10 @@ export function sortTagRepoTeamProject(
 
 export function sortPullRequests(
   a: PullRequestModel,
-  b: PullRequestModel
+  b: PullRequestModel,
+  order: SortOrder
 ) {
-  return UserPreferencesInstance.selectedDefaultSorting === "asc"
+  return order === SortOrder.ascending
     ? comparePullRequestAge(a, b)
     : -comparePullRequestAge(a, b); // Invert if descending
 }

--- a/src/tabs/PullRequestsTab.tsx
+++ b/src/tabs/PullRequestsTab.tsx
@@ -134,6 +134,9 @@ export class PullRequestsTab extends React.Component<
       errorMessage: "",
       pullRequestCount: 0,
       savedProjects: [],
+      sortOrder: UserPreferencesInstance.selectedDefaultSorting === "asc"
+        ? SortOrder.ascending
+        : SortOrder.descending
     };
 
     this.filter = new Filter();
@@ -511,8 +514,9 @@ export class PullRequestsTab extends React.Component<
       })
       .finally(async () => {
         if (newPullRequestList.length > 0) {
+          const { sortOrder } = this.state;
           pullRequests.push(...newPullRequestList);
-          pullRequests = pullRequests.sort(Data.sortPullRequests);
+          pullRequests = pullRequests.sort((a, b) => Data.sortPullRequests(a, b, sortOrder));
 
           this.setState({
             pullRequests,
@@ -934,6 +938,7 @@ export class PullRequestsTab extends React.Component<
           pullRequests
         )
       );
+      this.setState({ sortOrder: proposedSortOrder });
     });
 
     if (

--- a/src/tabs/PullRequestsTab.tsx
+++ b/src/tabs/PullRequestsTab.tsx
@@ -1074,15 +1074,7 @@ export class PullRequestsTab extends React.Component<
     null, // Title column
     null, // Details column
     // Sort on When column
-    (
-      item1: PullRequestModel.PullRequestModel,
-      item2: PullRequestModel.PullRequestModel
-    ): number => {
-      return (
-        item2.gitPullRequest.creationDate.getTime() -
-        item1.gitPullRequest.creationDate.getTime()
-      );
-    },
+    Data.comparePullRequestAge,
     null, // Reviewers column
   ];
 


### PR DESCRIPTION
Fixes #203 by storing the sorting direction in the `state` object. This means on a table refresh the sorting direction is rememberd instead of falling back to the default sorting from the user preferences. This was causing the sorting icon (arrow) to be opposite of the actual sorting applied.

On a whole page refresh or switching between tabs (Active, Recently Completed, Recently Abandoned) the sorting is still reset as usual.