### PR TITLE
Revert "Make pull request button a link"

### DIFF
--- a/src/components/Columns.tsx
+++ b/src/components/Columns.tsx
@@ -96,7 +96,6 @@ export function TitleColumn(
           <Button
             className="branch-button text-ellipsis"
             text={tableItem.title}
-            href={tableItem.pullRequestHref!}
             onClick={onClickPullRequestTitleHandler}
             tooltipProps={{ text: tooltip }}
             subtle={true}


### PR DESCRIPTION
Reverts cribeiro84/azure-devops-pull-request-hub#262 due the issue it has created that's now opening the PR details on both new window and same tab.